### PR TITLE
Give write id-token permissions to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     environment: publish
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
This is required for the job to verify itself properly to PyPI, see: https://docs.pypi.org/trusted-publishers/using-a-publisher/