### PR TITLE
Limit list of ids

### DIFF
--- a/src/texase/table.py
+++ b/src/texase/table.py
@@ -322,8 +322,6 @@ class TexaseTable(DataTable):
 
         Parameters
         ----------
-        row_id : int
-            The row id of the row to update.
         key_value_pairs : dict
             A dictionary of key-value pairs to update.
 

--- a/src/texase/table.py
+++ b/src/texase/table.py
@@ -405,7 +405,7 @@ class TexaseTable(DataTable):
         column_name = self.column_at_cursor()
 
         # Create the question
-        ids_str = ", ".join([str(id) for id in ids])
+        ids_str = re_range(ids)
         plural = [" ", "s "][no_rows > 1]
         q = f"Do you want to delete the key value pair{plural}"
         q += f"[bold]{column_name}[/bold] in row{plural}"

--- a/src/texase/table.py
+++ b/src/texase/table.py
@@ -455,7 +455,7 @@ class TexaseTable(DataTable):
         no_rows = len(ids)
 
         # Create the question
-        ids_str = ", ".join([str(id) for id in ids])
+        ids_str = re_range(ids)
         plural = [" ", "s "][no_rows > 1]
         q = f"Do you want to delete the row{plural}"
         q += f"with id{plural}" + f"[bold]{ids_str}[/bold]?"
@@ -591,3 +591,42 @@ def get_id_from_row(row) -> int:
 
 def get_column_labels(columns) -> list:
     return [str(c.label) for c in columns.values()]
+
+
+def list_formatter(start: int, end: int, step: int) -> str:
+    return f"{start}-{end}" if step == 1 else f"{start}-{end}:{step}"
+
+
+def re_range(lst: list[int]) -> str:
+    """Return a string representation of a list of integers.
+
+    The integers are grouped into ranges if they are consecutive. The
+    exact implementation is lifted from here:
+    https://stackoverflow.com/questions/9847601/convert-list-of-numbers-to-string-ranges
+
+    """
+    n = len(lst)
+    result = []
+    scan = 0
+    while n - scan > 2:
+        step = lst[scan + 1] - lst[scan]
+        if lst[scan + 2] - lst[scan + 1] != step:
+            result.append(str(lst[scan]))
+            scan += 1
+            continue
+
+        for j in range(scan + 2, n - 1):
+            if lst[j + 1] - lst[j] != step:
+                result.append(list_formatter(lst[scan], lst[j], step))
+                scan = j + 1
+                break
+        else:
+            result.append(list_formatter(lst[scan], lst[-1], step))
+            return ",".join(result)
+
+    if n - scan == 1:
+        result.append(str(lst[scan]))
+    elif n - scan == 2:
+        result.append(",".join(map(str, lst[scan:])))
+
+    return ",".join(result)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,87 @@
+import pytest
+from texase.table import TexaseTable, get_column_labels, list_formatter, re_range
+from textual.coordinate import Coordinate
+
+
+def get_column_index(table: TexaseTable, column_name: str) -> int:
+    """Get the index of a column by its name."""
+    labels = get_column_labels(table.columns)
+    if column_name not in labels:
+        raise ValueError(f"Column '{column_name}' not found in table columns.")
+    return labels.index(column_name)
+
+
+@pytest.mark.parametrize(
+    "column,editable",
+    [
+        ("mass", False),
+        ("pbc", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_table_is_cell_editable(loaded_app, column, editable):
+    app, _ = loaded_app
+    table: TexaseTable = app.query_one(TexaseTable)
+
+    column_index = get_column_index(table, column)
+
+    table.cursor_coordinate = Coordinate(0, column_index)
+
+    editable = table.is_cell_editable()
+    assert editable is editable
+
+
+@pytest.mark.asyncio
+async def test_update_row_editable_cells_updates_cells(loaded_app):
+    """update_row_editable_cells() should update only existing columns on the current row."""
+    app, _ = loaded_app
+    table: TexaseTable = app.query_one(TexaseTable)
+
+    col_idx = get_column_index(table, "pbc")
+    table.cursor_coordinate = Coordinate(1, col_idx)
+
+    # Make an update dict that includes a nonexistent column too
+    updates = {
+        "pbc": "FTF",
+        "this_column_does_not_exist": "SHOULD_BE_SKIPPED",
+    }
+
+    table.update_row_editable_cells(updates)
+
+    # Assert only the two real columns changed
+    cell1 = table.get_cell_at(Coordinate(table.cursor_row, col_idx))
+    assert str(cell1) == "FTF"
+
+
+# Tests for list_formatter(start, end, step)
+@pytest.mark.parametrize(
+    "start,end,step,expected",
+    [
+        (1, 4, 1, "1-4"),
+        (5, 5, 1, "5-5"),
+        (2, 10, 2, "2-10:2"),
+        (7, 9, 2, "7-9:2"),
+    ],
+)
+def test_list_formatter(start, end, step, expected):
+    assert list_formatter(start, end, step) == expected
+
+
+# Tests for re_range(lst)
+@pytest.mark.parametrize(
+    "input_list,expected",
+    [
+        ([1], "1"),
+        ([1, 2], "1,2"),
+        ([1, 2, 3], "1-3"),
+        ([1, 2, 3, 4, 6, 8], "1-4,6,8"),
+        ([1, 3, 5, 7], "1-7:2"),
+        ([1, 2, 4, 5, 7], "1,2,4,5,7"),
+        ([2, 4, 7, 10, 13], "2,4-13:3"),
+        ([10, 8, 6, 4], "10-4:-2"),  # re_range doesn't sort
+    ],
+)
+def test_re_range(input_list: list, expected: str):
+    # Ensure original order doesn't matter
+    output = re_range(input_list)
+    assert output == expected


### PR DESCRIPTION
When deleting rows of key-value pairs, the list of affected row ids is printed. Here we group the list of ids in ranges. It looks better and limits the screen use.

Fixes #6 